### PR TITLE
security: default to sanitize: true

### DIFF
--- a/lib/markdown/markdown.service.ts
+++ b/lib/markdown/markdown.service.ts
@@ -39,7 +39,7 @@ export class MarkdownService {
         tables: true,
         breaks: false,
         pedantic: false,
-        sanitize: false,
+        sanitize: true,
         smartLists: true,
         smartypants: false
       },


### PR DESCRIPTION
This library currently creates an XSS vulnerability by default. Sanitize should be the default, and users should have to opt-in to potential XSS injection.